### PR TITLE
[Fix] Downgraded `markupsafe` to 1.1.1 to be compatible with kytos

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -56,7 +56,7 @@ jinja2==2.11.1
     # via kytos-utils
 lazy-object-proxy==1.7.1
     # via astroid
-markupsafe==2.0.1
+markupsafe==1.1.1
     # via
     #   jinja2
     #   kytos-utils

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -14,7 +14,7 @@ idna==3.3
     # via requests
 jinja2==2.11.1
     # via -r requirements/run.in
-markupsafe==2.0.1
+markupsafe==1.1.1
     # via jinja2
 pathspec==0.9.0
     # via -r requirements/run.in


### PR DESCRIPTION
Although we've pinned [`jinja2==2.11.1`](https://github.com/kytos-ng/kytos-utils/blob/master/requirements/run.in#L4), its dependency, `markupsafe`, ended-up getting bumped, and we need this to be the same version as kytos currently [has pinned on `1.1.1`](https://github.com/kytos-ng/kytos/blob/master/requirements/run.txt#L21)

Thanks for catching this @italovalcy 