### PR TITLE
release: bumped 2023.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,27 +3,17 @@ Changelog
 #########
 This is a log of changes made to the *kytos-utils* project.
 
+[2023.1.0] - 2023-06-05
+***********************
+
+No major changes since the last release
+
 [2022.3.1]
-******************************
-Added
-=====
+**********
 
 Changed
 =======
 - Updated requirements to be compatible with kytos: ``click==8.1.3``, ``jinja2==3.1.2``, ``markupsafe==2.1.1``
-
-Deprecated
-==========
-
-Removed
-=======
-
-Fixed
-=====
-
-Security
-========
-
 
 [2022.3.0] - 2023-01-23
 ***********************

--- a/kytos/utils/metadata.py
+++ b/kytos/utils/metadata.py
@@ -2,7 +2,7 @@
 
 The present metadata is intended to be used mainly on the setup.
 """
-__version__ = '2022.3.1'
+__version__ = '2023.1.0'
 __author__ = 'Kytos Team'
 __author_email__ = 'devel@lists.kytos.io'
 __license__ = 'MIT'


### PR DESCRIPTION
### Summary

- Bumped `2023.1.0` and updated changelog.

### Local Tests

Not needed

### End-to-End Tests

Not needed (e2e nightly tests are passing)
