### PR TITLE
Fix ruamel name in requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -111,7 +111,7 @@ pytest-cov==4.1.0
     # via kytos-utils
 requests==2.31.0
     # via kytos-utils
-ruamel-yaml==0.17.19
+ruamel.yaml==0.17.19
     # via kytos-utils
 tomlkit==0.11.8
     # via pylint

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -20,7 +20,7 @@ pathspec==0.9.0
     # via -r requirements/run.in
 requests==2.31.0
     # via -r requirements/run.in
-ruamel-yaml==0.17.19
+ruamel.yaml==0.17.19
     # via -r requirements/run.in
 urllib3==1.26.18
     # via requests


### PR DESCRIPTION
Fixes an issue, where trying to install kytos-utils would generate an error. Using pip tools to generate `run.txt` and `dev.txt` appears to be produce an invalid name for `ruamel.yaml`.